### PR TITLE
canvas の端をクリックした場合でも, Fruit が範囲内に生成されるように変更.

### DIFF
--- a/game.js
+++ b/game.js
@@ -103,9 +103,9 @@ function getRandomFruitType() {
 class Fruit {
     constructor(type, x, y) {
         this.type = type;
-        this.x = x;
-        this.y = y;
         this.radius = FRUITS[this.type].size;
+        this.x = Math.min(Math.max(x, this.radius), canvas.width - this.radius);
+        this.y = y;
         this.dy = 0;
         this.dx = (x > canvas.width / 2) ? -2 : 2;
         this.framesSinceCreation = 0;


### PR DESCRIPTION
canvas の左右の端をクリックした際に Fruit が範囲外に生成されてしまうので, x 座標を強制的に範囲内に収めるように変更した.